### PR TITLE
[BUG] Properly clean system cache when closing instances

### DIFF
--- a/chromadb/api/client.py
+++ b/chromadb/api/client.py
@@ -476,13 +476,6 @@ class Client(SharedSystemClient, ClientAPI):
 
     # endregion
 
-    @override
-    def __del__(self) -> None:
-        # only enforce resource clean-up for ephemeral clients - expand to others?
-        if self._identifier == "ephemeral":
-            self.close()
-        super().__del__()
-
 
 class AdminClient(SharedSystemClient, AdminAPI):
     _server: ServerAPI

--- a/chromadb/api/client.py
+++ b/chromadb/api/client.py
@@ -1,4 +1,5 @@
 from typing import ClassVar, Dict, Optional, Sequence
+from collections import defaultdict
 from uuid import UUID
 import uuid
 
@@ -32,6 +33,7 @@ import chromadb.utils.embedding_functions as ef
 
 class SharedSystemClient:
     _identifer_to_system: ClassVar[Dict[str, System]] = {}
+    _refcount: ClassVar[defaultdict[str, int]] = defaultdict(int)
     _identifier: str
 
     # region Initialization
@@ -41,6 +43,7 @@ class SharedSystemClient:
     ) -> None:
         self._identifier = SharedSystemClient._get_identifier_from_settings(settings)
         SharedSystemClient._create_system_if_not_exists(self._identifier, settings)
+        SharedSystemClient._refcount[self._identifier] += 1
 
     @classmethod
     def _create_system_if_not_exists(
@@ -104,12 +107,20 @@ class SharedSystemClient:
     @staticmethod
     def clear_system_cache() -> None:
         SharedSystemClient._identifer_to_system = {}
+        SharedSystemClient._refcount.clear()
 
     @property
     def _system(self) -> System:
         return SharedSystemClient._identifer_to_system[self._identifier]
 
     # endregion
+
+    def __del__(self) -> None:
+        if self._identifier in SharedSystemClient._refcount:
+            SharedSystemClient._refcount[self._identifier] -= 1
+            if SharedSystemClient._refcount[self._identifier] == 0:
+                del SharedSystemClient._identifer_to_system[self._identifier]
+                del SharedSystemClient._refcount[self._identifier]
 
 
 class Client(SharedSystemClient, ClientAPI):
@@ -464,6 +475,13 @@ class Client(SharedSystemClient, ClientAPI):
         self._server.close()
 
     # endregion
+
+    @override
+    def __del__(self) -> None:
+        # only enforce resource clean-up for ephemeral clients - expand to others?
+        if self._identifier == "ephemeral":
+            self.close()
+        super().__del__()
 
 
 class AdminClient(SharedSystemClient, AdminAPI):

--- a/chromadb/test/test_client.py
+++ b/chromadb/test/test_client.py
@@ -315,3 +315,14 @@ def test_http_client_use_after_close(http_api: ClientAPI) -> None:
             http_api.count_collections()
         with pytest.raises(RuntimeError, match="Component not running"):
             http_api.heartbeat()
+
+
+def test_delete_ephemeral_client() -> None:
+    client = chromadb.EphemeralClient()
+    coll = client.get_or_create_collection("test")
+    coll.add(ids="1", documents="a", embeddings=[1] * 128)
+    del client
+
+    client = chromadb.EphemeralClient()
+    with pytest.raises(Exception):
+        client.get_collection("test").get()

--- a/chromadb/test/test_client.py
+++ b/chromadb/test/test_client.py
@@ -321,6 +321,7 @@ def test_delete_ephemeral_client() -> None:
     client = chromadb.EphemeralClient()
     coll = client.get_or_create_collection("test")
     coll.add(ids="1", documents="a", embeddings=[1] * 128)
+    client.close()
     del client
 
     client = chromadb.EphemeralClient()


### PR DESCRIPTION
## Description of changes

*Summarize the changes made by this PR.*
 - Improvements & Bug fixes
	 - When using several ephemeral clients one after another (eg in testing) the ephemeral database is not GC'ed and there is no easy and documented way to clean those resources, leading to issues (#1976). By automatically counting references in the system cache and cleaning unused systems, and with the close() functionality of PR #1792, this PR fixes that.
 - New functionality
	 - Automatic cleaning of system cache in the \_\_del\_\_ method, with class-level reference counts.

Note: no automatic call to close() is added and it is assumed that the user should explicitly close() its instance. For ephemeral clients, it might make sense to close autmatically on deletion, but this would be a possibly breaking change.

## Test plan
*How are these changes tested?*

- [x] Tests pass locally with `pytest` for python, `yarn test` for js, `cargo test` for rust

## Documentation Changes
*Are all docstrings for user-facing APIs updated if required? Do we need to make documentation changes in the [docs repository](https://github.com/chroma-core/docs)?*
